### PR TITLE
Make layout more responsive

### DIFF
--- a/colorGame.css
+++ b/colorGame.css
@@ -2,6 +2,10 @@ body{
 	background-color: #232323;
 	margin: 0;
 	font-family: "Montserrat";
+	display: flex;
+	flex-direction: column;
+	height: 100vh;
+	font-size: 16px;
 }
 h1{
 	color: white;
@@ -12,50 +16,63 @@ h1{
 	text-transform: uppercase;
 	line-height: 1.1;
 	padding: 13px 0;
-	font-size: 40px;
+	font-size: 1.5rem;
+}
+@media screen and (min-width: 768px) {
+	h1 {
+		font-size: 2.5rem;
+	}
+}
+button{
+	appearance: none;
+	background: none;
+	border-style: none;
 }
 .square{
-	background-color: red;
-	width : 30%;
-	height: 10%;
-	padding-bottom: 25%;
-	float: left;
-	margin: 1.66%;
-	border-radius: 25%;
+	background-color: transparent;
+	border-radius: 2vmin;
 	transition: background 0.5s;
 	-webkit-transition: background 0.5s;
 	-moz-transition: background 0.5s;
 }
 #message{
 	display: inline-block;
-	width: 30%;
 	color: #3D069B;
-	letter-spacing: 1px;
+	letter-spacing: 0.0625em;
 	font-weight: 500;
-	padding-left: 5%;
+	margin-left: 1rem;
 }
 #container{
-	max-width: 600px;
-	margin: 13px auto;
+	flex: auto;
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	padding: 1rem;
+	grid-gap: 1rem;
 }
 #strip{
 	background: white;
-	height: 30px;
 	text-align: center;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 0 1rem;
 }
 button{
 	border: none;
 	background: none;
-	height: 100%;
 	text-transform: uppercase;
 	font-weight: 700;
-	letter-spacing: 1px;
+	letter-spacing: 0.0625em;
 	font-size: inherit;
 	color: steelblue;
 	transition: all 0.4s;
 	-webkit-transition: all 0.5s;
 	-moz-transition: all 0.5s;
 	outline: none;
+	padding: 0.3em;
+}
+#difficulty {
+	min-height: 100%;
 }
 button:hover{
 	color: white;

--- a/colorGame.html
+++ b/colorGame.html
@@ -15,9 +15,11 @@
 <div id="strip">
 	<button id="reset">New Colors</button>
 	<span id="message"></span>
-	<button class="mode">Easy</button>
-	<button class="mode">Medium</button>
-	<button class="mode selected">Hard</button>
+	<div id="difficulty">
+		<button class="mode">Easy</button>
+		<button class="mode">Medium</button>
+		<button class="mode selected">Hard</button>
+	</div>
 </div>
 <div id="container">
 	<div class="square"></div>


### PR DESCRIPTION
- Use flexbox for overall layout, filling the viewport
- Make final flex area expand to fill
- Make this final flex area a grid with three columns, and with gaps between
- Make color swatches fill their cells
- Style options strip as a flex with space between items; group difficulty buttons so they stay together
- Set font sizes to be relative
- Don't boost font size of color prompt so much for narrow viewports

Closes #1